### PR TITLE
Fix stat in maddening frame

### DIFF
--- a/src/main/java/magicbees/main/utils/compat/bloodmagic/ItemFrenziedFrame.java
+++ b/src/main/java/magicbees/main/utils/compat/bloodmagic/ItemFrenziedFrame.java
@@ -39,7 +39,7 @@ public class ItemFrenziedFrame extends EnergyItems implements IHiveFrame {
 
         @Override
         public float getLifespanModifier(IBeeGenome genome, IBeeGenome mate, float currentModifier) {
-            return 0.0001f;
+            return 1;
         }
 
         @Override


### PR DESCRIPTION
Likely was a copy/paste error from the other frame. see https://github.com/GTNewHorizons/MagicBees/pull/20 or https://discord.com/channels/181078474394566657/1029918255932002395/1102044489952002130 for the intended stats.

specifically the maddening frame of frenze having a (oblivion like) lifespan redution.