### PR TITLE
Apply same GTNH coremod check to bee product

### DIFF
--- a/src/main/java/magicbees/bees/BeeProductHelper.java
+++ b/src/main/java/magicbees/bees/BeeProductHelper.java
@@ -131,7 +131,6 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
-import cpw.mods.fml.common.Loader;
 import gregtech.api.enums.Materials;
 import magicbees.item.types.CombType;
 import magicbees.item.types.DropType;
@@ -262,7 +261,7 @@ public class BeeProductHelper {
     }
 
     public static void initOreDictSProducts() {
-        boolean isGTLoaded = Loader.isModLoaded("gregtech");
+        boolean isGTLoaded = Config.isGTNHCoreModLoaded;
         SILVER.addProduct(ForestryHelper.itemHoneycomb, 0.10f);
         if (OreDictionary.getOres("nuggetSilver").size() > 0) {
             SILVER.addSpecialty(


### PR DESCRIPTION
So it won't crash with GT6
The commit did similar thing but unfinished: https://github.com/GTNewHorizons/MagicBees/commit/fb43f46bb8545bb3fe8ec24a5a89bdd1cf75904b