### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/magicbees/lang/en_US.lang
+++ b/src/main/resources/assets/magicbees/lang/en_US.lang
@@ -40,6 +40,7 @@ tile.magicApiary.name=Magic Apiary
 tile.visAuraProvider.name=Vis Apiary Booster
 tile.apimancersDrainer.name=Apimancer's Drainer
 tile.manaAuraProvider.name=Mana Apiary Booster
+tile.hive.name=Hive
 tile.hive.curious.name=Curious Hive
 tile.hive.unusual.name=Unusual Hive
 tile.hive.deep.name=Deep Hive
@@ -49,6 +50,7 @@ tile.hive.oblivion.name=Oblivion Hive
 tile.enchantedEarth.name=Enchanted Earth
 
 #Combs
+item.comb.name=Comb
 comb.mundane=Mundane Comb
 comb.molten=Molten Comb
 comb.occult=Occult Comb
@@ -78,11 +80,13 @@ comb.TElux=Lux Comb
 comb.TEendearing=Endearing Comb
 
 #Waxes
+item.wax.name=Wax
 wax.magic=Magic Wax
 wax.soul=Soulful Wax
 wax.amnesic=Amnesic Wax
 
 #Drops
+item.drop.name=Drop
 drop.enchanting=Enchanting Drop
 drop.intellect=Intellect Drop
 drop.destabilized=Destabilized Drop
@@ -91,10 +95,12 @@ drop.lux=Lux Drop
 drop.endearing=Endearing Drop
 
 #Pollens
+item.pollen.name=Pollen
 pollen.unusual=Unusual Pollen
 pollen.phased=Phased Pollen
 
 #Nuggets
+item.beeNugget.name=Nugget
 nugget.iron=Iron Nugget
 nugget.steel=Steel Nugget
 nugget.copper=Copper Nugget
@@ -106,6 +112,7 @@ nugget.emerald=Emerald Shard
 nugget.apatite=Apatite Shard
 
 #Propolises
+item.propolis.name=Propolis
 propolis.dull=Ordered Propolis
 propolis.air=Breezey Propolis
 propolis.fire=Burning Propolis
@@ -115,6 +122,7 @@ propolis.magic=Chaotic Propolis
 propolis.unstable=Unstable Propolis
 
 #Misc resources
+item.miscResources.name=Resource
 resource.fragment=Lore Fragment
 resource.lump=Aromatic Lump
 resource.fertilizer=Concentrated Compound
@@ -151,7 +159,9 @@ item.frenziedFrame.name=Maddening Frame of Frenzy
 item.bloodSoakedFrame.name=Blood Frame
 
 #Capsules
+item.capsule.magic.name=Magic Capsule
 capsule.magic=%s Magic Capsule
+item.capsule.void.name=Void Capsule
 capsule.void=%s Void Capsule
 
 #Liquids
@@ -203,6 +213,8 @@ moon.new=New Moon
 #moon.alt.new=
 
 #Backpack
+item.backpack.thaumaturgeT1.name=Thaumaturge's Backpack
+item.backpack.thaumaturgeT2.name=Thaumaturge's Backpack
 backpack.thaumaturge=Thaumaturge's Backpack
 
 #Itemgroups


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.