### PR TITLE
Give Enchanted Earth some minimal hardness

### DIFF
--- a/src/main/java/magicbees/block/BlockEnchantedEarth.java
+++ b/src/main/java/magicbees/block/BlockEnchantedEarth.java
@@ -28,6 +28,7 @@ public class BlockEnchantedEarth extends Block {
         setBlockTextureName(CommonProxy.DOMAIN + ":enchantedEarth");
         setTickRandomly(true);
         setStepSound(soundTypeGravel);
+        setHardness(0.1F);
     }
 
     @Override


### PR DESCRIPTION
This block has no hardness and can be mined with a simple left click, which can be annoying if you're gathering crops that are planted on it.

It seems reasonable to assume this was an omission since other blocks defined in this mod all have hardness. `BlockDirt` might have been it's inspiration and it also lacks a hardness as part of it's constructor since it is set through setters post construction.

I gave it the same hardness as snow as not to inconvenience anyone used to easily gathering up these blocks.