### PR TITLE
Un-hide Hives

### DIFF
--- a/src/main/java/magicbees/block/types/HiveType.java
+++ b/src/main/java/magicbees/block/types/HiveType.java
@@ -25,9 +25,9 @@ public enum HiveType {
     CURIOUS("curious", BeeSpecies.MYSTICAL, 12, true),
     UNUSUAL("unusual", BeeSpecies.UNUSUAL, 12, true),
     RESONANT("resonant", BeeSpecies.SORCEROUS, 12, true),
-    DEEP("deep", BeeSpecies.ATTUNED, 4, false),
-    INFERNAL("infernal", BeeSpecies.INFERNAL, 15, false),
-    OBLIVION("oblivion", BeeSpecies.OBLIVION, 7, false),;
+    DEEP("deep", BeeSpecies.ATTUNED, 4, true),
+    INFERNAL("infernal", BeeSpecies.INFERNAL, 15, true),
+    OBLIVION("oblivion", BeeSpecies.OBLIVION, 7, true),;
 
     private static String[] nameList;
 


### PR DESCRIPTION
Technically unhides from creative inventory, practically from NEI. They can be obtained from Vending machine or meteors, so no point of having them hidden in NEI.

(Deep Hive, Infernal Hive, Oblivion Hive)


Resolves https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24249