### PR TITLE
Fix magic apiary GUI bypassing claim protection

### DIFF
--- a/src/main/java/magicbees/block/BlockEffectJar.java
+++ b/src/main/java/magicbees/block/BlockEffectJar.java
@@ -36,7 +36,9 @@ public class BlockEffectJar extends BlockContainer {
         boolean activate = false;
 
         if (!player.isSneaking()) {
-            player.openGui(MagicBees.object, UIScreens.EFFECT_JAR.ordinal(), world, x, y, z);
+            if (!world.isRemote) {
+                player.openGui(MagicBees.object, UIScreens.EFFECT_JAR.ordinal(), world, x, y, z);
+            }
             activate = true;
         }
 

--- a/src/main/java/magicbees/block/BlockMagicApiary.java
+++ b/src/main/java/magicbees/block/BlockMagicApiary.java
@@ -40,7 +40,9 @@ public class BlockMagicApiary extends BlockContainer {
         boolean activate = false;
 
         if (!player.isSneaking()) {
-            player.openGui(MagicBees.object, UIScreens.THAUMIC_APIARY.ordinal(), world, x, y, z);
+            if (!world.isRemote) {
+                player.openGui(MagicBees.object, UIScreens.THAUMIC_APIARY.ordinal(), world, x, y, z);
+            }
             activate = true;
         }
 


### PR DESCRIPTION
## Summary
- `BlockMagicApiary.onBlockActivated()` called `player.openGui()` on both client and server instead of server-only, causing the client to open a phantom GUI with windowId=0
- When claim protection mods (e.g. ServerUtilities) cancelled the server-side interaction and sent forceUpdate(inventoryContainer)`, the window-0 packets were misapplied to the phantom apiary container - causing the player's equipped armor to appear in the produce slots
- Added `!world.isRemote` guard so the GUI is only opened server-side, matching standard Forge practice