### PR TITLE
Cache enum `.values()`

### DIFF
--- a/src/main/java/magicbees/bees/BeeGenomeManager.java
+++ b/src/main/java/magicbees/bees/BeeGenomeManager.java
@@ -19,7 +19,7 @@ public class BeeGenomeManager {
 
     // Basic genome for All thaumic bees.
     private static IAllele[] getTemplateModBase() {
-        IAllele[] genome = new IAllele[EnumBeeChromosome.values().length];
+        IAllele[] genome = new IAllele[EnumBeeChromosome.VALUES.length];
 
         genome[EnumBeeChromosome.SPECIES.ordinal()] = BeeSpecies.MYSTICAL.getSpecies();
         genome[EnumBeeChromosome.SPEED.ordinal()] = Allele.getBaseAllele("speedSlowest");

--- a/src/main/java/magicbees/block/BlockHive.java
+++ b/src/main/java/magicbees/block/BlockHive.java
@@ -43,7 +43,7 @@ public class BlockHive extends Block {
     @Override
     public int getLightValue(IBlockAccess world, int x, int y, int z) {
         int meta = world.getBlockMetadata(x, y, z);
-        if (meta < 0 || meta > HiveType.values().length) {
+        if (meta < 0 || meta > HiveType.VALUES.length) {
             meta = 0;
         }
         return HiveType.getHiveFromMeta(meta).getLightValue();
@@ -54,7 +54,7 @@ public class BlockHive extends Block {
     @Override
     public void getSubBlocks(Item item, CreativeTabs tab, List itemsList) {
         // Java bitches about raw types & types not being checked. Sorry, but the API sucks.
-        for (HiveType type : HiveType.values()) {
+        for (HiveType type : HiveType.VALUES) {
             if (type.show || Config.forestryDebugEnabled) {
                 itemsList.add(new ItemStack(this, 1, type.ordinal()));
             }
@@ -75,7 +75,7 @@ public class BlockHive extends Block {
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIcon(int side, int meta) {
-        if (meta < 0 || meta > HiveType.values().length) {
+        if (meta < 0 || meta > HiveType.VALUES.length) {
             meta = 0;
         }
         return HiveType.getHiveFromMeta(meta).getIconForSide(side);

--- a/src/main/java/magicbees/block/types/HiveType.java
+++ b/src/main/java/magicbees/block/types/HiveType.java
@@ -29,6 +29,8 @@ public enum HiveType {
     INFERNAL("infernal", BeeSpecies.INFERNAL, 15, true),
     OBLIVION("oblivion", BeeSpecies.OBLIVION, 7, true),;
 
+    public static final HiveType[] VALUES = values();
+
     private static String[] nameList;
 
     private String name;
@@ -43,8 +45,8 @@ public enum HiveType {
     public static HiveType getHiveFromMeta(int meta) {
         HiveType type = CURIOUS;
 
-        if (meta > 0 && meta < HiveType.values().length) {
-            type = HiveType.values()[meta];
+        if (meta > 0 && meta < HiveType.VALUES.length) {
+            type = HiveType.VALUES[meta];
         }
 
         return type;
@@ -96,7 +98,7 @@ public enum HiveType {
 
     @SideOnly(Side.CLIENT)
     public static void registerIcons(IIconRegister register) {
-        for (HiveType type : HiveType.values()) {
+        for (HiveType type : HiveType.VALUES) {
             type.icons = new IIcon[2];
 
             type.icons[0] = register.registerIcon(CommonProxy.DOMAIN + ":beehive." + type.ordinal() + ".top");
@@ -167,9 +169,9 @@ public enum HiveType {
     }
 
     private static String[] generateNames() {
-        String[] names = new String[values().length];
+        String[] names = new String[VALUES.length];
         for (int i = 0; i < names.length; ++i) {
-            names[i] = values()[i].name;
+            names[i] = VALUES[i].name;
         }
         return names;
     }

--- a/src/main/java/magicbees/item/ItemDrop.java
+++ b/src/main/java/magicbees/item/ItemDrop.java
@@ -37,7 +37,7 @@ public class ItemDrop extends Item {
     @SideOnly(Side.CLIENT)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void getSubItems(Item item, CreativeTabs tabs, List list) {
-        for (DropType type : DropType.values()) {
+        for (DropType type : DropType.VALUES) {
             list.add(this.getStackForType(type));
         }
     }
@@ -70,11 +70,11 @@ public class ItemDrop extends Item {
     @Override
     @SideOnly(Side.CLIENT)
     public int getColorFromItemStack(ItemStack stack, int pass) {
-        int meta = Math.max(0, Math.min(DropType.values().length - 1, stack.getItemDamage()));
-        int colour = DropType.values()[meta].combColour[0];
+        int meta = Math.max(0, Math.min(DropType.VALUES.length - 1, stack.getItemDamage()));
+        int colour = DropType.VALUES[meta].combColour[0];
 
         if (pass >= 1) {
-            colour = DropType.values()[meta].combColour[1];
+            colour = DropType.VALUES[meta].combColour[1];
         }
 
         return colour;
@@ -82,6 +82,6 @@ public class ItemDrop extends Item {
 
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
-        return DropType.values()[stack.getItemDamage()].getName();
+        return DropType.VALUES[stack.getItemDamage()].getName();
     }
 }

--- a/src/main/java/magicbees/item/ItemNugget.java
+++ b/src/main/java/magicbees/item/ItemNugget.java
@@ -37,7 +37,7 @@ public class ItemNugget extends Item {
     @SideOnly(Side.CLIENT)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void getSubItems(Item item, CreativeTabs tab, List list) {
-        for (NuggetType type : NuggetType.values()) {
+        for (NuggetType type : NuggetType.VALUES) {
             if (type.isActive()) {
                 list.add(new ItemStack(item, 1, type.ordinal()));
             }
@@ -46,12 +46,12 @@ public class ItemNugget extends Item {
 
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister par1IconRegister) {
-        this.icons = new IIcon[NuggetType.values().length];
-        for (int i = 0; i < NuggetType.values().length; i++) {
+        this.icons = new IIcon[NuggetType.VALUES.length];
+        for (int i = 0; i < NuggetType.VALUES.length; i++) {
             this.icons[i] = par1IconRegister.registerIcon(
                     CommonProxy.DOMAIN + ":nugget"
-                            + NuggetType.values()[i].name().substring(0, 1)
-                            + NuggetType.values()[i].name().substring(1).toLowerCase());
+                            + NuggetType.VALUES[i].name().substring(0, 1)
+                            + NuggetType.VALUES[i].name().substring(1).toLowerCase());
         }
     }
 
@@ -63,6 +63,6 @@ public class ItemNugget extends Item {
 
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
-        return NuggetType.values()[stack.getItemDamage()].getName();
+        return NuggetType.VALUES[stack.getItemDamage()].getName();
     }
 }

--- a/src/main/java/magicbees/item/ItemPropolis.java
+++ b/src/main/java/magicbees/item/ItemPropolis.java
@@ -36,7 +36,7 @@ public class ItemPropolis extends Item {
     @SideOnly(Side.CLIENT)
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public void getSubItems(Item item, CreativeTabs tabs, List list) {
-        for (PropolisType type : PropolisType.values()) {
+        for (PropolisType type : PropolisType.VALUES) {
             list.add(this.getStackForType(type));
         }
     }
@@ -50,14 +50,14 @@ public class ItemPropolis extends Item {
     public int getColorFromItemStack(ItemStack stack, int pass) {
         int colour = 0xffffff;
         int meta = stack.getItemDamage();
-        if (meta >= 0 && meta < PropolisType.values().length) {
-            colour = PropolisType.values()[meta].colour;
+        if (meta >= 0 && meta < PropolisType.VALUES.length) {
+            colour = PropolisType.VALUES[meta].colour;
         }
         return colour;
     }
 
     @Override
     public String getItemStackDisplayName(ItemStack stack) {
-        return PropolisType.values()[stack.getItemDamage()].getName();
+        return PropolisType.VALUES[stack.getItemDamage()].getName();
     }
 }

--- a/src/main/java/magicbees/item/types/DropType.java
+++ b/src/main/java/magicbees/item/types/DropType.java
@@ -11,7 +11,9 @@ public enum DropType {
     LUX("lux", 0xF5F3A4, 0xC9C87D),
     ENDEARING("endearing", 0x12E3D9, 0x069E97),;
 
-    private DropType(String pName, int colourA, int colourB) {
+    public static final DropType[] VALUES = values();
+
+    DropType(String pName, int colourA, int colourB) {
         this.name = pName;
         this.combColour[0] = colourA;
         this.combColour[1] = colourB;

--- a/src/main/java/magicbees/item/types/NuggetType.java
+++ b/src/main/java/magicbees/item/types/NuggetType.java
@@ -15,6 +15,8 @@ public enum NuggetType {
     EMERALD,
     APATITE,;
 
+    public static final NuggetType[] VALUES = values();
+
     private Item targetIngot;
     private boolean active;
 

--- a/src/main/java/magicbees/item/types/PropolisType.java
+++ b/src/main/java/magicbees/item/types/PropolisType.java
@@ -13,7 +13,9 @@ public enum PropolisType {
     ORDER("dull", 0xDDDDFF),
     CHAOS("magic", 0x555577),;
 
-    private PropolisType(String pName, int overlayColour) {
+    public static final PropolisType[] VALUES = values();
+
+    PropolisType(String pName, int overlayColour) {
         this.name = pName;
         this.colour = overlayColour;
     }

--- a/src/main/java/magicbees/main/Config.java
+++ b/src/main/java/magicbees/main/Config.java
@@ -462,7 +462,7 @@ public class Config {
     private void setupNuggets() {
         nuggets = new ItemNugget();
         String item;
-        for (NuggetType type : NuggetType.values()) {
+        for (NuggetType type : NuggetType.VALUES) {
             LogHelper.info("Found nugget of type " + type.toString());
             item = type.toString().toLowerCase();
             item = Character.toString(item.charAt(0)).toUpperCase() + item.substring(1);

--- a/src/main/java/magicbees/main/Config.java
+++ b/src/main/java/magicbees/main/Config.java
@@ -442,7 +442,7 @@ public class Config {
         hive = new BlockHive();
         GameRegistry.registerBlock(hive, ItemMagicHive.class, "hive");
 
-        for (HiveType t : HiveType.values()) {
+        for (HiveType t : HiveType.VALUES) {
             hive.setHarvestLevel("scoop", 0, t.ordinal());
         }
     }


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
caching enum values() calls that got called more than 500 times during my little playtest.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
